### PR TITLE
✨ LINEアカウント連携機能を実装

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,20 @@
+class Api::V1::UsersController < Api::V1::BaseController
+  require 'net/http'
+  require 'uri'
+
+  def update
+    id_token = params[:idToken]
+    channel_id = ENV["LIFF_CHANNEL_ID"]
+    
+    res = Net::HTTP.post_form(URI.parse('https://api.line.me/oauth2/v2.1/verify'), { 'id_token' => id_token, 'client_id' => channel_id })
+    line_user_id = JSON.parse(res.body)['sub']
+
+    #if user.nil?
+    #  user = User.create(line_user_id:)
+    #elsif (session[:user_id] = user.id)
+    #  render json: user
+    #end
+    render json: current_user
+
+  end
+end

--- a/app/lib/line_api_client.rb
+++ b/app/lib/line_api_client.rb
@@ -1,0 +1,25 @@
+require 'net/http'
+require 'uri'
+
+module LineApiClient
+  LINE_CHANNEL_ID = ENV["LINE_CHANNEL_ID"].freeze
+
+  def get_line_user_id(id_token)
+    uri = URI.parse('https://api.line.me/oauth2/v2.1/verify')
+    res = Net::HTTP.post_form(uri, {
+      'id_token' => id_token,
+      'client_id' => LINE_CHANNEL_ID
+    })
+    if res.is_a?(Net::HTTPSuccess)
+      JSON.parse(res.body)['sub']
+    else
+      nil
+    end
+  rescue Net::ReadTimeout, Net::OpenTimeout
+    Rails.logger.error("LINE ID Token verification request timed out.")
+    nil
+  rescue StandardError => e
+    Rails.logger.error("An error occurred during LINE ID Token verification: #{e.message}")
+    nil
+  end
+end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'localhost:8000', 'localhost:5173', 'https://laterless.vercel.app'
+    origins 'localhost:8000', 'localhost:8001', 'localhost:5173', 'https://laterless.vercel.app'
     resource '*',
       headers: :any,
       methods: [:get, :post, :put, :patch, :delete, :options, :head]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
           get 'check_duplicate'
         end
       end
+      resource :user, only: %i[update]
     end
   end
 end

--- a/test/controllers/api/v1/users_controller_test.rb
+++ b/test/controllers/api/v1/users_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## Issue
https://github.com/yushi32/superior_bookmark_app/issues/15

## 概要
LINEアカウント連携機能を実装

### 内容
- [x] `Users`コントローラーを作成し、`update`アクションと対応するルーティングを追加しました。
- [x] LINEサーバーにAPIリクエストを送る処理をまとめるモジュールを作成しました。

## 確認方法
- ヘッダーの「LINEアカウント連携」ボタンから`/line_connect`にアクセスし、ページに記載されている手順通りにアカウント連携作業が行える。

## チェックリスト
- [ ] 手順3までアカウント連携作業が進められる。
- [ ] Railsコンソールからユーザー情報を確認し、`line_user_id`カラムに値がセットされていることを確認する。

## コメント
手順3まで進めるにはローカルでHTTPS環境を構築する必要があるので、コードレビューのみで大丈夫です。
今回実装したLINEアカウント連携機能では、フロント側からのリクエストヘッダーにIDトークンを付与して、バックエンド側でIDトークンを検証することでLINEのユーザーIDを取得しています。
そのため、`update`メソッドの引数に通常のストロングパラメータを渡してレコードを更新することが出来ません。
なので、リクエストヘッダーに`X-LINE-AccessToken`が含まれているかどうかでストロングパラメータの戻り値を分岐するようにしました。
この部分の実装が適切に行えているか確認していただけると嬉しいです。