### PR TITLE
:wrench: Fly.ioにRedisデータベースを追加し、Sidekiqプロセスを設定

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -9,7 +9,12 @@ console_command = "/rails/bin/rails console"
 
 [build]
 
+[processes]
+app = "bin/rails server"
+worker = "bundle exec sidekiq"
+
 [http_service]
+  processes = ["app"]
   internal_port = 3000
   force_https = true
   auto_stop_machines = true


### PR DESCRIPTION
## Issue
https://github.com/yushi32/superior_bookmark_app/issues/33

## 概要
Fly.ioにRedisデータベースを追加し、Sidekiqプロセスを設定

### 内容
- [x] Fly.ioにデプロイしているRailsアプリケーションにRedisデータベースを追加しました。
- [x] アプリケーションサーバーとは別にバックグラウンドワーカーとしてSidekiqプロセスを起動するように設定しました。
- [x] RedisデータベースおよびSidekiqプロセスが正常に起動していることをFly.ioのコンソールから確認しました。

## コメント
本PRではFly.ioへのデプロイ作業を行いました。
プロダクションコードに対する変更や追加はありません。