### PR TITLE
✨ 自動タグ生成・付与機能を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem "dotenv-rails"
 gem "jsonapi-serializer"
 gem "alba"
 gem "sidekiq"
+gem "metainspector"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
     alba (3.0.1)
     bootsnap (1.17.0)
       msgpack (~> 1.2)
@@ -81,13 +83,35 @@ GEM
       reline (>= 0.3.1)
     dockerfile-rails (1.5.12)
       rails (>= 3.0.0)
+    domain_name (0.6.20240107)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
     erubi (1.12.0)
+    faraday (2.9.0)
+      faraday-net_http (>= 2.0, < 3.2)
+    faraday-cookie_jar (0.0.7)
+      faraday (>= 0.8.0)
+      http-cookie (~> 1.0.0)
+    faraday-encoding (0.0.5)
+      faraday
+    faraday-follow_redirects (0.3.0)
+      faraday (>= 1, < 3)
+    faraday-gzip (1.0.0)
+      faraday (>= 1.0)
+      zlib (~> 2.1)
+    faraday-http-cache (2.5.1)
+      faraday (>= 0.8)
+    faraday-net_http (3.1.0)
+      net-http
+    faraday-retry (2.2.0)
+      faraday (~> 2.0)
+    fastimage (2.3.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
@@ -106,10 +130,25 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.2)
+    metainspector (5.15.0)
+      addressable (~> 2.8.4)
+      faraday (~> 2.5)
+      faraday-cookie_jar (~> 0.0)
+      faraday-encoding (~> 0.0)
+      faraday-follow_redirects (~> 0.3)
+      faraday-gzip (>= 0.1, < 2.0)
+      faraday-http-cache (~> 2.5)
+      faraday-retry (~> 2.0)
+      fastimage (~> 2.2)
+      nesty (~> 1.0)
+      nokogiri (~> 1.13)
     method_source (1.0.0)
     mini_mime (1.1.5)
     minitest (5.20.0)
     msgpack (1.7.2)
+    nesty (1.0.2)
+    net-http (0.4.1)
+      uri
     net-imap (0.4.2)
       date
       net-protocol
@@ -133,6 +172,7 @@ GEM
       pry (>= 0.13, < 0.15)
     psych (5.1.1.1)
       stringio
+    public_suffix (5.0.4)
     puma (5.6.7)
       nio4r (~> 2.0)
     racc (1.7.1)
@@ -191,10 +231,12 @@ GEM
     timeout (0.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    uri (0.13.0)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     zeitwerk (2.6.12)
+    zlib (2.1.1)
 
 PLATFORMS
   aarch64-linux
@@ -208,6 +250,7 @@ DEPENDENCIES
   dotenv-rails
   jsonapi-serializer
   jwt
+  metainspector
   pg (~> 1.5.4)
   pry-byebug
   puma (~> 5.0)

--- a/app/controllers/api/v1/bookmarks_controller.rb
+++ b/app/controllers/api/v1/bookmarks_controller.rb
@@ -7,7 +7,8 @@ class Api::V1::BookmarksController < Api::V1::BaseController
 
   def create
     bookmark = current_user.bookmarks.build(bookmark_params)
-    if bookmark.save
+    auto_generate_tag = bookmark.generate_tag_from_url
+    if bookmark.save_with_tags(auto_generate_tag, current_user)
       json_string = BookmarkSerializer.new(bookmark).serialize
       render json: json_string
     else

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -24,8 +24,12 @@ class Bookmark < ApplicationRecord
     target_domain = URI.parse(url).host
     return nil if Bookmark.with_domain(target_domain).count < 2
 
+    # 取得したタイトルを仕切り文字で分割して、最初の非空文字列をタグ名とする
+    delimiters = [' ', '|', ':', '/', '-', 'ー', '　', '｜', '：', '／', '－']
+    delimiter_pattern = Regexp.union(delimiters.map { |delimiter| Regexp.escape(delimiter) })
+
     page = MetaInspector.new("https://#{target_domain}")
-    page.title
+    page.title.split(delimiter_pattern).reject(&:empty?).first
   end
 
   def save_with_tags(tag_name, current_user)

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,7 +1,7 @@
 class Bookmark < ApplicationRecord
   require 'metainspector'
 
-  validates :url, presence: true
+  validates :url, presence: true, uniqueness: { scope: :user_id }
   validates :title, presence: true
   validates :status, presence: true
   validates :caption, length: { maximum: 140 }

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -54,7 +54,11 @@ class Bookmark < ApplicationRecord
       save!
     end
     true
-  rescue StandardError
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique::Error => e
+    Rails.logger.error("An error occurred when creating a new Bookmark record: #{e.class} - #{e.message}")
+    false
+  rescue StandardError => e
+    Rails.logger.error("An error occurred when creating a new Bookmark record: #{e.class} - #{e.message}")
     false
   end
   

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,9 +1,9 @@
 class Tag < ApplicationRecord
-  validates :name, presence: true
-  
   has_many :user_tags, dependent: :destroy
   has_many :users, through: :user_tags
   has_many :bookmark_tags
   has_many :bookmarks, through: :bookmark_tags
   has_many :notifications, as: :category, dependent: :nullify
+
+  validates :name, presence: true, uniqueness: true
 end

--- a/db/migrate/20240130072456_add_unique_index_to_tag_name.rb
+++ b/db/migrate/20240130072456_add_unique_index_to_tag_name.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToTagName < ActiveRecord::Migration[7.0]
+  def change
+    add_index :tags, :name, unique: true
+  end
+end

--- a/db/migrate/20240130084052_add_unique_index_to_bookmark_url_user_id.rb
+++ b/db/migrate/20240130084052_add_unique_index_to_bookmark_url_user_id.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToBookmarkUrlUserId < ActiveRecord::Migration[7.0]
+  def change
+    add_index :bookmarks, [:url, :user_id], unique: true
+  end
+end

--- a/db/migrate/20240130085719_add_unique_index_to_user_tag_user_id_tag_id.rb
+++ b/db/migrate/20240130085719_add_unique_index_to_user_tag_user_id_tag_id.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToUserTagUserIdTagId < ActiveRecord::Migration[7.0]
+  def change
+    add_index :user_tags, [:user_id, :tag_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_30_084052) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_30_085719) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -80,6 +80,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_30_084052) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["tag_id"], name: "index_user_tags_on_tag_id"
+    t.index ["user_id", "tag_id"], name: "index_user_tags_on_user_id_and_tag_id", unique: true
     t.index ["user_id"], name: "index_user_tags_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_28_175355) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_30_072456) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -70,6 +70,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_28_175355) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
   create_table "user_tags", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_30_072456) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_30_084052) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -35,6 +35,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_30_072456) do
     t.datetime "updated_at", null: false
     t.bigint "folder_id"
     t.index ["folder_id"], name: "index_bookmarks_on_folder_id"
+    t.index ["url", "user_id"], name: "index_bookmarks_on_url_and_user_id", unique: true
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 

--- a/fly.toml
+++ b/fly.toml
@@ -14,7 +14,6 @@ app = "bin/rails server"
 worker = "bundle exec sidekiq"
 
 [http_service]
-  processes = ["app"]
   internal_port = 3000
   force_https = true
   auto_stop_machines = true


### PR DESCRIPTION
## Issue
https://github.com/yushi32/superior_bookmark_app/issues/23

## 概要
自動タグ生成・付与機能を実装

### 内容
- [x] gem 'MetaInspector'をインストールしました。
- [x] `Bookmark`モデルに自動でタグを生成・付与する`generate_tag_from_url`メソッドを追加しました。
- [x] `Bookmark`モデルに同じドメインを持つレコード数を取得するscopeメソッド`with_domain`を追加しました。
- [x] `Bookmarks`コントローラーの`create`アクションに自動でタグを生成・付与する処理を追加しました。
- [x] 以下のモデルの属性と対応するテーブルにユニーク制約を追加しました。
  - `Tag`モデルの`name`属性
  - `Bookmark`モデルの`url`属性と`user_id`属性の組み合わせ 

## 確認方法
- 同じドメインを持つブックマークが2件存在する状態で、新しくブックマークを作成すると自動でタグが付与されている。

## チェックリスト
- [ ] 同じドメインを持つブックマークが2件存在する状態で、新しくブックマークを作成すると自動でタグが付与されている。
  - 下の画像のようになれば大丈夫です！
[![Image from Gyazo](https://i.gyazo.com/0027802367942e6193c926920f6c0cdc.png)](https://gyazo.com/0027802367942e6193c926920f6c0cdc)

## コメント
今回のPRではブックマーク新規作成時に自動でタグを付与する機能を実装しました。
新規作成したブックマークのURLからトップページの`title`タグの文字列を取得してタグを生成・付与しています。
サイト名だけが記載されている場合と「サイト名 | 説明文」のような形式の場合があるので、正規表現を用いてサイト名だけを取得するようにしています。