### PR TITLE
🐛 自動タグ生成の判定ロジックでブックマーク全体ではなくユーザーごとのブックマークを参照するように修正

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -18,11 +18,11 @@ class Bookmark < ApplicationRecord
     selected_ids = unnotified_ids.sample(3)
     where(id: selected_ids).order(id: :asc)
   }
-  scope :with_domain, ->(domain) { where('url LIKE ?', "%#{domain}%") }
 
   def generate_tag_from_url
     target_domain = URI.parse(url).host
-    return nil if Bookmark.with_domain(target_domain).count < 2
+    same_domain_count = user.bookmarks.where('url LIKE ?', "%#{target_domain}%").count
+    return nil if same_domain_count < 2
 
     # 取得したタイトルを仕切り文字で分割して、最初の非空文字列をタグ名とする
     delimiters = [' ', '|', ':', '/', '-', 'ー', '　', '｜', '：', '／', '－']


### PR DESCRIPTION
## issue
https://github.com/yushi32/superior_bookmark_app/issues/35

## 概要
自動タグ生成の判定ロジックを修正

### 内容
- [x] 新規ブックマーク作成時のタグ自動生成ロジックで、同じドメインのブックマーク数を数える処理をすべてのブックマークを対象にしていたため、ユーザーごとのブックマークのみを対象とするように変更
- [x] 他のユーザーのブックマークに影響されずに機能することを確認