### PR TITLE
🐛 本番環境でRedisに過剰にコマンドが送られてしまう問題に対処

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,6 @@
 Sidekiq.configure_server do |config|
   config.redis = { url: ENV['REDIS_URL'] }
+  Sidekiq::BasicFetch::TIMEOUT = 60
 end
 
 Sidekiq.configure_client do |config|

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,7 +2,7 @@ Sidekiq.configure_server do |config|
   config.redis = { url: ENV['REDIS_URL'] }
   Sidekiq::BasicFetch::TIMEOUT = 60
   Sidekiq::Launcher.send(:remove_const, 'BEAT_PAUSE')
-  Sidekiq::Launcher.const_set('BEAT_PAUSE', 50)
+  Sidekiq::Launcher.const_set('BEAT_PAUSE', 90)
 end
 
 Sidekiq.configure_client do |config|

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,6 +1,8 @@
 Sidekiq.configure_server do |config|
   config.redis = { url: ENV['REDIS_URL'] }
   Sidekiq::BasicFetch::TIMEOUT = 60
+  Sidekiq::Launcher.send(:remove_const, 'BEAT_PAUSE')
+  Sidekiq::Launcher.const_set('BEAT_PAUSE', 50)
 end
 
 Sidekiq.configure_client do |config|

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,5 @@
 :concurrency: 3
 :queues:
   - default
-:retry: 5 
+:retry: 5
+:poll_interval_average: 60

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,4 @@
-:concurrency: 5
+:concurrency: 3
 :queues:
   - default
 :retry: 5 


### PR DESCRIPTION
## Issue
https://github.com/yushi32/superior_bookmark_app/issues/36

## 概要
本番環境でRedisに過剰にコマンドが送られてしまう問題に対処

### 内容
- [x] Sidekiqの設定を以下のように変更しました。
  - キューにジョブがない時にポーリングする間隔を60秒に変更
  - 平均ポーリング間隔を60秒に変更
  - ハートビートの間隔を90秒に変更
  - スレッド数を3に変更

## コメント
本PRでは本番環境でRedisに過剰にコマンドを送られてしまう問題について調査と対処を行いました。
現在利用しているUpstash Redisの1日の利用上限が10000件となっていて、4時間ほどでこれに達してしまう問題が発生していました。
調査の結果、Sidekiqが自身のプロセス情報を定期的にRedisに記録するハートビートという機能とスケジュールされたジョブとリトライジョブのキューをポーリングする頻度が細かかったことが原因だったので、これらの設定を変更しました。

ハートビートの記録は60秒で揮発してしまうため、今の設定ではSidekiqプロセスの死活管理として機能しているとは言えない状況ですが、以下の理由から暫定の対処としています。
- ハートビートの記録が揮発するぎりぎりの59秒だと1日の利用上限を突破してしまうこと。
- ハートビートの記録時に前回の記録が揮発してしまっていても、それを受けて自身を再起動するような仕組みがSidekiqに用意されていないため、運用上とりあえず問題がないこと。