### PR TITLE
✨ サムネイル表示機能に必要なデータを受け渡す

### DIFF
--- a/app/controllers/api/v1/bookmarks_controller.rb
+++ b/app/controllers/api/v1/bookmarks_controller.rb
@@ -49,6 +49,6 @@ class Api::V1::BookmarksController < Api::V1::BaseController
   private
 
   def bookmark_params
-    params.require(:bookmark).permit(:url, :title, :status, :folder_id)
+    params.require(:bookmark).permit(:url, :title, :thumbnail, :status, :folder_id)
   end
 end

--- a/app/serializers/bookmark_serializer.rb
+++ b/app/serializers/bookmark_serializer.rb
@@ -4,7 +4,7 @@ class BookmarkSerializer
   # 与えられたオブジェクトがコレクションであるかどうかに応じて、返却するJSONのルートキーの単数系・複数形を自動で設定する
   root_key!
 
-  attributes :id, :title, :url, :folder_id
+  attributes :id, :title, :url, :thumbnail, :folder_id
 
   many :tags, resource: TagSerializer
 end


### PR DESCRIPTION
## Issue
https://github.com/yushi32/superior_bookmark_app/issues/37

## 概要
ユーザーが追加したブックマークに対して、フロントエンドでリンク先のサムネイルを表示するために必要なデータをバックエンドから提供する機能を実装しました。

### 内容
- [x] `Bookmarks`コントローラーのストロングパラメータに`thumbnail`属性を追加しました。
- [x] `Bookmark`シリアライザーに`thumbnail`属性を追加しました。

## 確認方法
- OGPが設定されているページをブックマークに追加すると、サムネイルが表示される。
  - 本アプリのURL（[https://laterless.vercel.app](https://laterless.vercel.app)）などをブックマークに追加してサムネイルが表示されれば大丈夫です。

## チェックポイント
- [ ] OGPが設定されているページをブックマークに追加すると、サムネイルが表示される。

## コメント
今回のPRではブックマークのサムネイルを表示するために、バックエンドからフロントエンドに必要なデータを受け渡す機能を実装しました。
今後、サムネイルとしてOGPだけでなくファビコンを表示したり、動画ページの場合はサムネイルを取得して表示する機能の追加を検討しています。