### PR TITLE
✨ ブックマーク編集機能を実装

### DIFF
--- a/app/controllers/api/v1/bookmarks_controller.rb
+++ b/app/controllers/api/v1/bookmarks_controller.rb
@@ -8,7 +8,8 @@ class Api::V1::BookmarksController < Api::V1::BaseController
   def create
     bookmark = current_user.bookmarks.build(bookmark_params)
     auto_generate_tag = bookmark.generate_tag_from_url
-    if bookmark.save_with_tags(auto_generate_tag, current_user)
+    tag_names = auto_generate_tag ? [auto_generate_tag] : []
+    if bookmark.save_with_tags(tag_names, current_user)
       json_string = BookmarkSerializer.new(bookmark).serialize
       render json: json_string
     else

--- a/app/controllers/api/v1/bookmarks_controller.rb
+++ b/app/controllers/api/v1/bookmarks_controller.rb
@@ -49,6 +49,6 @@ class Api::V1::BookmarksController < Api::V1::BaseController
   private
 
   def bookmark_params
-    params.require(:bookmark).permit(:url, :title, :thumbnail, :status, :folder_id)
+    params.require(:bookmark).permit(:url, :title, :thumbnail, :note, :status, :folder_id)
   end
 end

--- a/app/controllers/api/v1/bookmarks_controller.rb
+++ b/app/controllers/api/v1/bookmarks_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::BookmarksController < Api::V1::BaseController
   def update
     bookmark = current_user.bookmarks.includes(:tags).find(params[:id])
     bookmark.assign_attributes(bookmark_params)
-    if bookmark.save_with_tags(params.dig(:bookmark, :tag_name), current_user)
+    if bookmark.save_with_tags(params.dig(:bookmark, :tag_names), current_user)
       json_string = BookmarkSerializer.new(bookmark).serialize
       render json: json_string
     else

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -42,14 +42,15 @@ class Bookmark < ApplicationRecord
     end
   end
 
-  def save_with_tags(tag_name, current_user)
+  def save_with_tags(tag_names, current_user)
     ActiveRecord::Base.transaction do
-      if tag_name.present?
-        new_tag = Tag.find_or_create_by(name: tag_name)
-        add_tag(new_tag) unless tagged?(new_tag.id)
+      if tag_names.present?
+        tag_names.each do |tag_name|
+          new_tag = Tag.find_or_create_by(name: tag_name)
+          add_tag(new_tag) unless tagged?(new_tag.id)
 
-        current_user.add_tag(new_tag) unless current_user.tag_used?(new_tag.id)
-
+          current_user.add_tag(new_tag) unless current_user.tag_used?(new_tag.id)
+        end
       end
       save!
     end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -53,12 +53,7 @@ class Bookmark < ApplicationRecord
         tags_to_remove = current_tags - tag_names
 
         # 未登録のタグを追加する
-        tag_names.each do |tag_name|
-          new_tag = Tag.find_or_create_by(name: tag_name)
-          add_tag(new_tag) unless tagged?(new_tag.id)
-
-          current_user.add_tag(new_tag) unless current_user.tag_used?(new_tag.id)
-        end
+        add_new_tags(tag_names, current_user)
 
         # タグの削除処理
         if tags_to_remove.present?
@@ -80,6 +75,15 @@ class Bookmark < ApplicationRecord
   end
 
   private
+
+  def add_new_tags(tag_names, current_user)
+    tag_names.each do |tag_name|
+      new_tag = Tag.find_or_create_by(name: tag_name)
+      add_tag(new_tag) unless tagged?(new_tag.id)
+
+      current_user.add_tag(new_tag) unless current_user.tag_used?(new_tag.id)
+    end
+  end
 
   def add_tag(tag)
     tags << tag

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -44,9 +44,9 @@ class Bookmark < ApplicationRecord
 
   def save_with_tags(tag_names, current_user)
     ActiveRecord::Base.transaction do
-      # tag_namesが空の場合、すべてのタグを削除する
+      # tag_namesが空の場合、関連付けられているすべてのタグを削除する
       if tag_names.blank?
-        tags.clear
+        tags.clear if tags.present?
       else
         # 更新前のタグと差分を特定
         current_tags = tags.pluck(:name)

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -44,7 +44,10 @@ class Bookmark < ApplicationRecord
 
   def save_with_tags(tag_names, current_user)
     ActiveRecord::Base.transaction do
-      if tag_names.present?
+      # tag_namesが空の場合、すべてのタグを削除する
+      if tag_names.blank?
+        tags.clear
+      else
         # 更新前のタグと差分を特定
         current_tags = tags.pluck(:name)
         tags_to_remove = current_tags - tag_names

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -45,11 +45,21 @@ class Bookmark < ApplicationRecord
   def save_with_tags(tag_names, current_user)
     ActiveRecord::Base.transaction do
       if tag_names.present?
+        current_tags = tags.pluck(:name)
+        tags_to_remove = current_tags - tag_names
+
         tag_names.each do |tag_name|
           new_tag = Tag.find_or_create_by(name: tag_name)
           add_tag(new_tag) unless tagged?(new_tag.id)
 
           current_user.add_tag(new_tag) unless current_user.tag_used?(new_tag.id)
+        end
+
+        if tags_to_remove.present?
+          tags_to_remove.each do |tag_name|
+            tag_to_remove = Tag.find_by(name: tag_name)
+            tags.delete(tag_to_remove)
+          end
         end
       end
       save!

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -56,12 +56,7 @@ class Bookmark < ApplicationRecord
         add_new_tags(tag_names, current_user)
 
         # タグの削除処理
-        if tags_to_remove.present?
-          tags_to_remove.each do |tag_name|
-            tag_to_remove = Tag.find_by(name: tag_name)
-            tags.delete(tag_to_remove)
-          end
-        end
+        remove_unused_tags(tags_to_remove)
       end
       save!
     end
@@ -82,6 +77,15 @@ class Bookmark < ApplicationRecord
       add_tag(new_tag) unless tagged?(new_tag.id)
 
       current_user.add_tag(new_tag) unless current_user.tag_used?(new_tag.id)
+    end
+  end
+
+  def remove_unused_tags(tags_to_remove)
+    return unless tags_to_remove.present?
+
+    tags_to_remove.each do |tag_name|
+      tag_to_remove = Tag.find_by(name: tag_name)
+      tags.delete(tag_to_remove)
     end
   end
 

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -45,9 +45,11 @@ class Bookmark < ApplicationRecord
   def save_with_tags(tag_names, current_user)
     ActiveRecord::Base.transaction do
       if tag_names.present?
+        # 更新前のタグと差分を特定
         current_tags = tags.pluck(:name)
         tags_to_remove = current_tags - tag_names
 
+        # 未登録のタグを追加する
         tag_names.each do |tag_name|
           new_tag = Tag.find_or_create_by(name: tag_name)
           add_tag(new_tag) unless tagged?(new_tag.id)
@@ -55,6 +57,7 @@ class Bookmark < ApplicationRecord
           current_user.add_tag(new_tag) unless current_user.tag_used?(new_tag.id)
         end
 
+        # タグの削除処理
         if tags_to_remove.present?
           tags_to_remove.each do |tag_name|
             tag_to_remove = Tag.find_by(name: tag_name)

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -4,7 +4,7 @@ class Bookmark < ApplicationRecord
   validates :url, presence: true, uniqueness: { scope: :user_id }
   validates :title, presence: true
   validates :status, presence: true
-  validates :note, length: { maximum: 140 }
+  validates :note, length: { maximum: 500 }
 
   belongs_to :user
   belongs_to :folder, optional: true

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -8,7 +8,7 @@ class Bookmark < ApplicationRecord
 
   belongs_to :user
   belongs_to :folder, optional: true
-  has_many :bookmark_tags, dependent: :destroy
+  has_many :bookmark_tags, -> { order(created_at: :asc) }, dependent: :destroy
   has_many :tags, through: :bookmark_tags
 
   enum status: { unnotified: 0, notified: 1, read: 2 }

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -4,7 +4,7 @@ class Bookmark < ApplicationRecord
   validates :url, presence: true, uniqueness: { scope: :user_id }
   validates :title, presence: true
   validates :status, presence: true
-  validates :caption, length: { maximum: 140 }
+  validates :note, length: { maximum: 140 }
 
   belongs_to :user
   belongs_to :folder, optional: true

--- a/app/serializers/bookmark_serializer.rb
+++ b/app/serializers/bookmark_serializer.rb
@@ -4,7 +4,7 @@ class BookmarkSerializer
   # 与えられたオブジェクトがコレクションであるかどうかに応じて、返却するJSONのルートキーの単数系・複数形を自動で設定する
   root_key!
 
-  attributes :id, :title, :url, :thumbnail, :folder_id
+  attributes :id, :title, :url, :thumbnail, :note, :folder_id
 
   many :tags, resource: TagSerializer
 end

--- a/db/migrate/20240315091301_rename_caption_to_note_in_bookmarks.rb
+++ b/db/migrate/20240315091301_rename_caption_to_note_in_bookmarks.rb
@@ -1,0 +1,5 @@
+class RenameCaptionToNoteInBookmarks < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :bookmarks, :caption, :note
+  end
+end

--- a/db/migrate/20240315093508_change_note_limit_in_bookmarks.rb
+++ b/db/migrate/20240315093508_change_note_limit_in_bookmarks.rb
@@ -1,0 +1,9 @@
+class ChangeNoteLimitInBookmarks < ActiveRecord::Migration[7.0]
+  def up
+    change_column :bookmarks, :note, :string, limit: 500
+  end
+
+  def down
+    change_column :bookmarks, :note, :string, limit: 140
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_15_091301) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_15_093508) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,7 +27,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_15_091301) do
     t.string "url", null: false
     t.string "title", null: false
     t.string "thumbnail"
-    t.string "note", limit: 140
+    t.string "note", limit: 500
     t.integer "status", default: 0
     t.boolean "recommendable", default: false
     t.bigint "user_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_30_085719) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_15_091301) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,7 +27,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_30_085719) do
     t.string "url", null: false
     t.string "title", null: false
     t.string "thumbnail"
-    t.string "caption", limit: 140
+    t.string "note", limit: 140
     t.integer "status", default: 0
     t.boolean "recommendable", default: false
     t.bigint "user_id", null: false


### PR DESCRIPTION
## Issue
https://github.com/yushi32/superior_bookmark_app/issues/21

## 概要
ブックマーク編集機能を実装
- [x] タイトルの編集
- [x] ノートの編集
- [x] 複数タグの一括登録・削除

### 内容
- [x] `bookmarks`テーブルの変更
  - `caption`カラムを`note`カラムにリネームしました。 
  - `note`カラムの上限文字数を140字から500字に変更しました。
- [x] フロントエンドとのデータを受け渡すための変更
  - `Bookmark`シリアライザーに`note`属性を追加しました。
  - `Bookmarks`コントローラーのストロングパラメータに`note`属性を追加しました。
- [x] 複数タグの一括登録・削除に対応しました。
  - `Bookmark`モデルの`save_with_tags`メソッド
  - `Bookmarks`コントローラーの`create`アクションと`update`アクション
- [x] ブックマークに関連付けられているタグを登録日時昇順に取得するように変更しました。
  - `Bookmark`モデル

## 確認方法
- 編集アイコンをクリックすると、ブックマーク詳細モーダルが表示される。
- ブックマーク詳細モーダルからタイトル、ノートの編集とタグの追加・削除が行える。
- タグが登録した順番に表示される。

## チェックリスト
- [ ] タイトルを編集できる。
- [ ] ノートを編集できる。
- [ ] 一度に複数のタグを登録・削除できる。
- [ ] タグが登録した順番に表示される。

## コメント
今回のPRではブックマーク編集機能を実装しました。

- ノート機能
ブックマークにメモする機能のために`caption`カラムを用意していましたが、ユーザーがより直感的に使用できるようにするため、表示名を「ノート」に変更したことに合わせて、カラム名を`note`に変更しました。
また、余裕を持ってノートを記述できるように上限文字数を500文字に引き上げました。

- 複数タグの一括登録・削除
ブックマーク詳細モーダルの実装に伴い、複数のタグを一括で登録・削除できるように`save_with_tags`メソッドを変更しました。

- 関連付けられているタグの並び替え
実装中に、既存のタグと後から追加したタグの並びが逆になっていることに気付き、登録した順番に並び替えて取得するようにアソシエーションを修正しました。